### PR TITLE
Add signalling of TestLifecycleAware containers

### DIFF
--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
@@ -1,51 +1,119 @@
 package org.testcontainers.junit.jupiter;
 
 import lombok.Getter;
-import org.junit.jupiter.api.extension.*;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.testcontainers.lifecycle.Startable;
+import org.testcontainers.lifecycle.TestDescription;
+import org.testcontainers.lifecycle.TestLifecycleAware;
 
 import java.lang.reflect.Field;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, TestInstancePostProcessor {
+import static java.util.stream.Collectors.toList;
+
+class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, AfterEachCallback, AfterAllCallback, TestInstancePostProcessor {
 
     private static final Namespace NAMESPACE = Namespace.create(TestcontainersExtension.class);
 
     private static final String TEST_INSTANCE = "testInstance";
+    private static final String SHARED_LIFECYCLE_AWARE_CONTAINERS = "sharedLifecycleAwareContainers";
+    private static final String LOCAL_LIFECYCLE_AWARE_CONTAINERS = "localLifecycleAwareContainers";
 
     @Override
     public void postProcessTestInstance(final Object testInstance, final ExtensionContext context) {
-        ExtensionContext.Store store = context.getStore(NAMESPACE);
+        Store store = context.getStore(NAMESPACE);
         store.put(TEST_INSTANCE, testInstance);
     }
 
     @Override
     public void beforeAll(ExtensionContext context) {
-        Class<?> testClass = context.getTestClass()
-            .orElseThrow(() -> new ExtensionConfigurationException("TestcontainersExtension is only supported for classes."));
+        Class<?> testClass = context.getTestClass().orElseThrow(() -> new ExtensionConfigurationException("TestcontainersExtension is only supported for classes."));
+        Store store = context.getStore(NAMESPACE);
 
-        ExtensionContext.Store store = context.getStore(NAMESPACE);
+        List<TestLifecycleAware> lifecycleAwareContainers = findSharedContainers(testClass)
+            .peek(adapter -> store.getOrComputeIfAbsent(adapter.getKey(), k -> adapter.start()))
+            .filter(this::isTestLifecycleAware)
+            .map(lifecycleAwareAdapter -> (TestLifecycleAware) lifecycleAwareAdapter.container)
+            .collect(toList());
 
-        findSharedContainers(testClass)
-            .forEach(adapter -> store.getOrComputeIfAbsent(adapter.getKey(), k -> adapter.start()));
+        store.put(SHARED_LIFECYCLE_AWARE_CONTAINERS, lifecycleAwareContainers);
+        signalBeforeTestToContainers(lifecycleAwareContainers, testDescriptionFrom(context));
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        signalAfterTestToContainersFor(SHARED_LIFECYCLE_AWARE_CONTAINERS, context);
     }
 
     @Override
     public void beforeEach(final ExtensionContext context) {
-        collectParentTestInstances(context)
-            .parallelStream()
+        Store store = context.getStore(NAMESPACE);
+
+        List<TestLifecycleAware> lifecycleAwareContainers = collectParentTestInstances(context).parallelStream()
             .flatMap(this::findRestartContainers)
-            .forEach(adapter -> context.getStore(NAMESPACE)
-                .getOrComputeIfAbsent(adapter.getKey(), k -> adapter.start()));
+            .peek(adapter -> store.getOrComputeIfAbsent(adapter.getKey(), k -> adapter.start()))
+            .filter(this::isTestLifecycleAware)
+            .map(lifecycleAwareAdapter -> (TestLifecycleAware) lifecycleAwareAdapter.container)
+            .collect(toList());
+
+        store.put(LOCAL_LIFECYCLE_AWARE_CONTAINERS, lifecycleAwareContainers);
+        signalBeforeTestToContainers(lifecycleAwareContainers, testDescriptionFrom(context));
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        signalAfterTestToContainersFor(LOCAL_LIFECYCLE_AWARE_CONTAINERS, context);
+    }
+
+    private void signalBeforeTestToContainers(List<TestLifecycleAware> lifecycleAwareContainers, TestDescription testDescription) {
+        lifecycleAwareContainers.forEach(container -> container.beforeTest(testDescription));
+    }
+
+    private void signalAfterTestToContainersFor(String storeKey, ExtensionContext context) {
+        List<TestLifecycleAware> lifecycleAwareContainers =
+            (List<TestLifecycleAware>) context.getStore(NAMESPACE).get(storeKey);
+        if (lifecycleAwareContainers != null) {
+            TestDescription description = testDescriptionFrom(context);
+            Optional<Throwable> throwable = context.getExecutionException();
+            lifecycleAwareContainers.forEach(container -> container.afterTest(description, throwable));
+        }
+    }
+
+    @NotNull
+    private TestDescription testDescriptionFrom(ExtensionContext context) {
+        return new TestDescription() {
+            @Override
+            public String getTestId() {
+                return context.getUniqueId();
+            }
+
+            @Override
+            public String getFilesystemFriendlyName() {
+                return context.getDisplayName();
+            }
+        };
+    }
+
+    private boolean isTestLifecycleAware(StoreAdapter adapter) {
+        return adapter.container instanceof TestLifecycleAware;
     }
 
     private Set<Object> collectParentTestInstances(final ExtensionContext context) {
@@ -63,12 +131,7 @@ class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, 
     }
 
     private Stream<StoreAdapter> findSharedContainers(Class<?> testClass) {
-        return ReflectionUtils.findFields(
-                testClass,
-                isSharedContainer(),
-                ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
-            .stream()
-            .map(f -> getContainerInstance(null, f));
+        return ReflectionUtils.findFields(testClass, isSharedContainer(), ReflectionUtils.HierarchyTraversalMode.TOP_DOWN).stream().map(f -> getContainerInstance(null, f));
     }
 
     private Predicate<Field> isSharedContainer() {
@@ -76,12 +139,7 @@ class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, 
     }
 
     private Stream<StoreAdapter> findRestartContainers(Object testInstance) {
-        return ReflectionUtils.findFields(
-                testInstance.getClass(),
-                isRestartContainer(),
-                ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
-            .stream()
-            .map(f -> getContainerInstance(testInstance, f));
+        return ReflectionUtils.findFields(testInstance.getClass(), isRestartContainer(), ReflectionUtils.HierarchyTraversalMode.TOP_DOWN).stream().map(f -> getContainerInstance(testInstance, f));
     }
 
     private Predicate<Field> isRestartContainer() {
@@ -93,7 +151,6 @@ class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, 
             boolean isAnnotatedWithContainer = AnnotationSupport.isAnnotated(field, Container.class);
             if (isAnnotatedWithContainer) {
                 boolean isStartable = Startable.class.isAssignableFrom(field.getType());
-
                 if (!isStartable) {
                     throw new ExtensionConfigurationException("Annotation is only supported for Startable types");
                 }


### PR DESCRIPTION
Allow containers like WebBrowserContainers to initialize and/or finalize
before/after tests.

This is a proof of concept kind of implementation. A test is also missing.